### PR TITLE
PWM initialization and setting functions

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/ROS-ArloRobot.iml
+++ b/.idea/ROS-ArloRobot.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (pythonProject)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ROS-ArloRobot.iml" filepath="$PROJECT_DIR$/.idea/ROS-ArloRobot.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/XY-160D-controller/scripts/motor-controller-interface.py
+++ b/XY-160D-controller/scripts/motor-controller-interface.py
@@ -1,19 +1,24 @@
 import Jetson.GPIO as GPIO
 
+
 def set_PWM_pin(PIN_nmb):
     GPIO.setmode(GPIO.BOARD)
     GPIO.setup(PIN_nmb, GPIO.OUT)
     xy_pwm = GPIO.PWM(PIN_nmb, 100)  # PWM object creation on pin 33, with 100Hz frequency
     xy_pwm.start(0)
+    return xy_pwm
 
 
 # Set duty cycle changes the duty cycle of a specific pwm_object
 def set_duty_cycle(duty_cycle, pwm_obj):
     pwm_obj.ChangeDutyCycle(duty_cycle)
+
+
 def main():
     # General GPIO setup
-    set_PWM_pin(33)
+    xy_pwm = set_PWM_pin(33)
     set_duty_cycle(70, xy_pwm)
+
 
 if __name__ == "__main__":
     main()

--- a/XY-160D-controller/scripts/motor-controller-interface.py
+++ b/XY-160D-controller/scripts/motor-controller-interface.py
@@ -1,4 +1,5 @@
 import Jetson.GPIO as GPIO
+import time
 
 
 def set_PWM_pin(PIN_nmb):
@@ -17,8 +18,22 @@ def set_duty_cycle(duty_cycle, pwm_obj):
 def main():
     # General GPIO setup
     xy_pwm = set_PWM_pin(33)
-    set_duty_cycle(70, xy_pwm)
-
+    # Jetson nano sample code to test pwm pin:
+    val = 25
+    incr = 5
+    print("PWM running. Press CTRL+C to exit.")
+    try:
+        while True:
+            time.sleep(0.25)
+            if val >= 100:
+                incr = -incr
+            if val <= 0:
+                incr = -incr
+            val += incr
+            xy_pwm.ChangeDutyCycle(val)
+    finally:
+        xy_pwm.stop()
+        GPIO.cleanup()
 
 if __name__ == "__main__":
     main()

--- a/XY-160D-controller/scripts/motor-controller-interface.py
+++ b/XY-160D-controller/scripts/motor-controller-interface.py
@@ -1,16 +1,18 @@
 import Jetson.GPIO as GPIO
 
-# Set duty cycle changes the duty cycle of a specific pwm_object
+def set_PWM_pin(PIN_nmb):
+    GPIO.setmode(GPIO.BOARD)
+    GPIO.setup(PIN_nmb, GPIO.OUT)
+    xy_pwm = GPIO.PWM(PIN_nmb, 100)  # PWM object creation on pin 33, with 100Hz frequency
+    xy_pwm.start(0)
 
+
+# Set duty cycle changes the duty cycle of a specific pwm_object
 def set_duty_cycle(duty_cycle, pwm_obj):
     pwm_obj.ChangeDutyCycle(duty_cycle)
 def main():
     # General GPIO setup
-    GPIO.setmode(GPIO.BOARD)
-    GPIO.setup(33, GPIO.OUT)
-
-    xy_pwm = GPIO.PWM(33, 100) # PWM object creation on pin 33, with 100Hz frequency
-    xy_pwm.start(0)
+    set_PWM_pin(33)
     set_duty_cycle(70, xy_pwm)
 
 if __name__ == "__main__":

--- a/XY-160D-controller/scripts/motor-controller-interface.py
+++ b/XY-160D-controller/scripts/motor-controller-interface.py
@@ -1,0 +1,17 @@
+import Jetson.GPIO as GPIO
+
+# Set duty cycle changes the duty cycle of a specific pwm_object
+
+def set_duty_cycle(duty_cycle, pwm_obj):
+    pwm_obj.ChangeDutyCycle(duty_cycle)
+def main():
+    # General GPIO setup
+    GPIO.setmode(GPIO.BOARD)
+    GPIO.setup(33, GPIO.OUT)
+
+    xy_pwm = GPIO.PWM(33, 100) # PWM object creation on pin 33, with 100Hz frequency
+    xy_pwm.start(0)
+    set_duty_cycle(70, xy_pwm)
+
+if __name__ == "__main__":
+    main()

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,2 @@
+[.ShellClassInfo]
+LocalizedResourceName=@ROS-ArloRobot,0


### PR DESCRIPTION
Created the function to initialize the relevant pin as PWM. 
The jetson nano board utilized uses pin 33

The main function has the sample jetson nano code for testing the pwm functionality